### PR TITLE
Bugfix - Check term is set

### DIFF
--- a/blocks/src/taxonomySelector/index.php
+++ b/blocks/src/taxonomySelector/index.php
@@ -34,7 +34,7 @@ function render( $attributes, $content, $block ) {
 		'<div %1$s>%2$s%3$s%4$s</div>',
 		$wrapper_attributes,
 		( $is_linked ) ? '<a href="' . \esc_url( \get_term_link( $term, $taxonomy ) ) . '" rel="tag">' : '',
-		\esc_html( $term->name ),
+		( ! empty( $term ) && ! is_wp_error( $term ) ) ? \esc_html( $term->name ) : '',
 		( $is_linked ) ? '</a>' : ''
 	);
 }


### PR DESCRIPTION
Fix

```php
Notice: Undefined property: WP_Error::$name in /var/www/html/wp-content/plugins/site-functionality/blocks/src/taxonomySelector/index.php on line 37 Notice: Undefined index: content in /var/www/html/wp-content/plugins/site-functionality/blocks/src/field/index.php on line 23 Notice: Undefined property: WP_Error::$name in /var/www/html/wp-content/plugins/site-functionality/blocks/src/taxonomySelector/index.php on line 37 Notice: Undefined index: content in /var/www/html/wp-content/plugins/site-functionality/blocks/src/field/index.php on line 23 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/site-functionality/blocks/src/taxonomySelector/index.php:37) in /var/www/html/wp-admin/admin-header.php on line 9
```